### PR TITLE
Create Unit Test for GetDefaultBalanceUseCase

### DIFF
--- a/feature/balance/build.gradle.kts
+++ b/feature/balance/build.gradle.kts
@@ -35,4 +35,5 @@ android {
 dependencies {
     implementation(libs.koin.android)
     implementation(libs.koin.core)
+    testImplementation(libs.junit)
 }

--- a/feature/balance/src/test/kotlin/com/thesetox/balance/GetDefaultBalanceUseCaseTest.kt
+++ b/feature/balance/src/test/kotlin/com/thesetox/balance/GetDefaultBalanceUseCaseTest.kt
@@ -1,0 +1,18 @@
+package com.thesetox.balance
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GetDefaultBalanceUseCaseTest {
+    @Test
+    fun `invoke returns EUR balance with initial amount`() {
+        // Arrange
+        val getDefaultBalance = GetDefaultBalanceUseCase()
+
+        // Act
+        val result = getDefaultBalance()
+
+        // Assert
+        assertEquals(listOf(Balance(code = "EUR", value = 1000.0)), result)
+    }
+}


### PR DESCRIPTION
## Summary
- refactor `GetDefaultBalanceUseCaseTest` to use Arrange-Act-Assert structure
- rename local variable to `getDefaultBalance`

## Testing
- `./gradlew :feature:balance:test --no-daemon --stacktrace --warning-mode all` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f8df65608328b8ff8b17a5bca382