### PR TITLE
Add unit tests for commission calculations

### DIFF
--- a/feature/comission/build.gradle.kts
+++ b/feature/comission/build.gradle.kts
@@ -35,4 +35,5 @@ android {
 dependencies {
     implementation(libs.koin.android)
     implementation(libs.koin.core)
+    testImplementation(libs.junit)
 }

--- a/feature/comission/src/test/java/com/thesetox/comission/GetCommissionUseCaseTest.kt
+++ b/feature/comission/src/test/java/com/thesetox/comission/GetCommissionUseCaseTest.kt
@@ -1,0 +1,31 @@
+package com.thesetox.comission
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GetCommissionUseCaseTest {
+    @Test
+    fun `first five conversions have zero commission`() {
+        // Arrange
+        val getCommission = GetCommissionUseCase()
+
+        // Act
+        val commissions = List(5) { getCommission(100.0, "EUR") }
+
+        // Assert
+        commissions.forEach { assertEquals(0.0, it, 0.0001) }
+    }
+
+    @Test
+    fun `commission applied after free conversions`() {
+        // Arrange
+        val getCommission = GetCommissionUseCase()
+
+        // Act
+        repeat(5) { getCommission(100.0, "EUR") }
+        val commission = getCommission(100.0, "EUR")
+
+        // Assert
+        assertEquals(100.0 * 0.007, commission, 0.0001)
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit dependency for commission module
- test first five conversions for zero commission
- verify commission applied after free conversions
- rename local variable to `getCommission` for clarity

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f8c6d600832891f054db1737dcb5