### PR TITLE
Refine GetListOfCurrencyUseCaseTest

### DIFF
--- a/feature/exchange/build.gradle.kts
+++ b/feature/exchange/build.gradle.kts
@@ -49,4 +49,9 @@ dependencies {
     implementation(libs.koin.androidx.compose)
     implementation(libs.koin.android)
     implementation(libs.koin.core)
+
+    // Test
+    testImplementation(libs.junit)
+    testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/feature/exchange/src/test/kotlin/com/thesetox/exchange/usecase/GetListOfCurrencyUseCaseTest.kt
+++ b/feature/exchange/src/test/kotlin/com/thesetox/exchange/usecase/GetListOfCurrencyUseCaseTest.kt
@@ -1,0 +1,54 @@
+package com.thesetox.exchange.usecase
+
+// Tests are structured using the AAA (Arrange-Act-Assert) pattern.
+
+import com.thesetox.database.CurrencyRateEntity
+import com.thesetox.exchange.repository.ExchangeRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class GetListOfCurrencyUseCaseTest {
+    private val repository = mock<ExchangeRepository>()
+
+    @Test
+    fun `invoke returns currency codes`() =
+        runTest {
+            // Arrange
+            whenever(repository.listOfCurrencyRate).thenReturn(
+                flowOf(
+                    listOf(
+                        CurrencyRateEntity(currencyCode = "USD"),
+                        CurrencyRateEntity(currencyCode = "JPY"),
+                    ),
+                ),
+            )
+
+            val getListOfCurrency = GetListOfCurrencyUseCase(repository)
+
+            // Act
+            val result = getListOfCurrency().first()
+
+            // Assert
+            assertEquals(listOf("USD", "JPY"), result)
+        }
+
+    @Test
+    fun `invoke collects list from repository`() =
+        runTest {
+            // Arrange
+            whenever(repository.listOfCurrencyRate).thenReturn(flowOf(emptyList()))
+            val getListOfCurrency = GetListOfCurrencyUseCase(repository)
+
+            // Act
+            getListOfCurrency().first()
+
+            // Assert
+            verify(repository).listOfCurrencyRate
+        }
+}


### PR DESCRIPTION
## Summary
- restructure GetListOfCurrencyUseCaseTest in AAA style
- split assertions into separate tests with one assert each
- add comment describing AAA pattern

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f63d07208328b8e6772c2ec56802