### PR TITLE
Add tests for CurrencyRateRemoteSource

### DIFF
--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -43,4 +43,10 @@ dependencies {
     // Koin
     implementation(libs.koin.android)
     implementation(libs.koin.core)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.ktor.client.mock)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.kotlin)
 }

--- a/core/network/src/test/kotlin/com/thesetox/network/CurrencyRateApiTest.kt
+++ b/core/network/src/test/kotlin/com/thesetox/network/CurrencyRateApiTest.kt
@@ -1,0 +1,92 @@
+package com.thesetox.network
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CurrencyRateApiTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `fetchCurrencyRates returns success`() =
+        runTest {
+            // Arrange
+            val mockEngine =
+                MockEngine {
+                    respond(
+                        content = """{"base":"EUR","date":"2020-01-01","rates":{"USD":1.2}}""",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf("Content-Type", "application/json"),
+                    )
+                }
+            val client =
+                HttpClient(mockEngine) {
+                    install(ContentNegotiation) { json(json) }
+                }
+            val api = CurrencyRateRemoteSource(client)
+
+            // Act
+            val result = api.fetchCurrencyRates()
+
+            // Assert
+            assertTrue(result is ApiResult.Success)
+        }
+
+    @Test
+    fun `fetchCurrencyRates returns error for non-successful response`() =
+        runTest {
+            // Arrange
+            val mockEngine = MockEngine { respondError(HttpStatusCode.InternalServerError) }
+            val client =
+                HttpClient(mockEngine) {
+                    install(ContentNegotiation) { json(json) }
+                }
+            val api = CurrencyRateRemoteSource(client)
+
+            // Act
+            val result = api.fetchCurrencyRates()
+
+            // Assert
+            assertTrue(result is ApiResult.Error)
+        }
+
+    @Test
+    fun `fetchCurrencyRates uses correct endpoint`() =
+        runTest {
+            // Arrange
+            var requestedUrl = ""
+            val mockEngine =
+                MockEngine { request ->
+                    requestedUrl = request.url.toString()
+                    respond(
+                        content = """{"base":"EUR","date":"2020-01-01","rates":{"USD":1.2}}""",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf("Content-Type", "application/json"),
+                    )
+                }
+            val client =
+                HttpClient(mockEngine) {
+                    install(ContentNegotiation) { json(json) }
+                }
+            val api = CurrencyRateRemoteSource(client)
+
+            // Act
+            api.fetchCurrencyRates()
+
+            // Assert
+            assertEquals(
+                "https://developers.paysera.com/tasks/api/currency-exchange-rates",
+                requestedUrl,
+            )
+        }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,10 +11,9 @@ ksp = "2.1.20-2.0.1"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
-mockitoKotlin = "5.4.0"
-
 
 # Mockito
+mockitoKotlin = "5.4.0"
 mockitoCore = "5.18.0"
 
 # Coroutines testing
@@ -76,6 +75,7 @@ ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "kto
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-client-serialization = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
+ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 
 # di
 koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin" }


### PR DESCRIPTION
## Summary
- restructure `CurrencyRateApiTest` to follow arrange/act/assert pattern
- verify request URL
- add Mockito dependencies for future use
- use `runTest` instead of `runBlocking` in tests

## Testing
- `./gradlew :core:network:test --no-daemon --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f50c936c83289cb4f79cb3ff9ee7