### PR TITLE
Document database module

### DIFF
--- a/core/database/src/main/kotlin/com/thesetox/database/DatabaseModule.kt
+++ b/core/database/src/main/kotlin/com/thesetox/database/DatabaseModule.kt
@@ -1,9 +1,19 @@
+/**
+ * Dependency injection definitions for the database layer of the application.
+ */
 package com.thesetox.database
 
 import androidx.room.Room
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
+/**
+ * Koin module that provides the Room database and its DAO dependencies.
+ *
+ * The module exposes a singleton instance of [ConversionAppDatabase] built with
+ * `Room.databaseBuilder` and a singleton [CurrencyRateDao] retrieved from the
+ * database. These can then be injected throughout the app.
+ */
 val databaseModule =
     module {
         single {


### PR DESCRIPTION
## Summary
- add KDoc for `databaseModule` and file header

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aa954574483289387bda883b175f3