### PR TITLE
Add Javadoc for datastore

### DIFF
--- a/core/datastore/src/main/kotlin/com/thesetox/datastore/AppDataStore.kt
+++ b/core/datastore/src/main/kotlin/com/thesetox/datastore/AppDataStore.kt
@@ -6,12 +6,32 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.first
 
+/**
+ * Abstraction over Jetpack DataStore used to persist small pieces of
+ * application state. Currently it stores the hash of the latest fetched
+ * currency rates so features can determine when fresh data is available.
+ */
 interface AppDataStore {
+    /**
+     * Retrieve the previously saved currency rate hash.
+     *
+     * @return the stored hash or an empty string if no value was saved
+     */
     suspend fun getCurrencyRateHash(): String
 
+    /**
+     * Persist the given currency rate hash.
+     *
+     * @param hash value to store
+     */
     suspend fun saveCurrencyRateHash(hash: String)
 }
 
+/**
+ * [AppDataStore] implementation backed by Jetpack [DataStore].
+ *
+ * @param dataStore underlying DataStore used for persistence
+ */
 class LocalDataSource(private val dataStore: DataStore<Preferences>) : AppDataStore {
     override suspend fun getCurrencyRateHash(): String {
         val preferences = dataStore.data.first()
@@ -26,6 +46,7 @@ class LocalDataSource(private val dataStore: DataStore<Preferences>) : AppDataSt
     }
 
     companion object {
+        /** Preference key used to store the currency rate hash. */
         private val HASH_KEY = stringPreferencesKey("HASH_KEY")
     }
 }


### PR DESCRIPTION
## Summary
- document `AppDataStore` and `LocalDataSource`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aa96f39d483289e25bc8b5081351c