### PR TITLE
Add KDoc for CurrencyRateResponse

### DIFF
--- a/core/network/src/main/kotlin/com/thesetox/network/CurrencyRateResponse.kt
+++ b/core/network/src/main/kotlin/com/thesetox/network/CurrencyRateResponse.kt
@@ -2,6 +2,14 @@ package com.thesetox.network
 
 import kotlinx.serialization.Serializable
 
+/**
+ * Model of the currency rates received from the remote service.
+ *
+ * @property base the currency used as the reference for all rates
+ * @property date the date when the rates were published
+ * @property rates a map of currency codes to their relative exchange rate
+ */
+
 @Serializable
 data class CurrencyRateResponse(
     val base: String,


### PR DESCRIPTION
## Summary
- document CurrencyRateResponse model with KDoc

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aaa2298288328aa50554abfd22875