### PR TITLE
Add documentation for network module

### DIFF
--- a/core/network/src/main/kotlin/com/thesetox/network/NetworkModule.kt
+++ b/core/network/src/main/kotlin/com/thesetox/network/NetworkModule.kt
@@ -8,14 +8,24 @@ import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
+/**
+ * Koin module that provides networking dependencies for the application.
+ *
+ * It exposes:
+ * - a configured [Json] instance used for Kotlinx serialization
+ * - a [HttpClient] with the `ContentNegotiation` plugin
+ * - the [CurrencyRateApi] implementation backed by [CurrencyRateRemoteSource]
+ */
 val networkModule =
     module {
+        // Provide the Json serializer configured to ignore unknown fields.
         single<Json> {
             Json {
                 ignoreUnknownKeys = true
             }
         }
 
+        // Create a Ktor HttpClient that uses the provided Json configuration.
         single<HttpClient> {
             HttpClient {
                 install(ContentNegotiation) {
@@ -24,5 +34,6 @@ val networkModule =
             }
         }
 
+        // Bind the remote source as the implementation for CurrencyRateApi.
         singleOf(::CurrencyRateRemoteSource) { bind<CurrencyRateApi>() }
     }


### PR DESCRIPTION
## Summary
- document Koin providers in `NetworkModule`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aaa30810483289ad4b87d8bfff12f