### PR TITLE
Add KDoc for Balance data class

### DIFF
--- a/feature/balance/src/main/kotlin/com/thesetox/balance/Balance.kt
+++ b/feature/balance/src/main/kotlin/com/thesetox/balance/Balance.kt
@@ -1,5 +1,11 @@
 package com.thesetox.balance
 
+/**
+ * Represents a single entry in the user's wallet.
+ *
+ * @property code ISO currency code such as "EUR" or "USD".
+ * @property value Numeric balance amount for the given currency.
+ */
 data class Balance(
     val code: String,
     val value: Double,


### PR DESCRIPTION
## Summary
- document `Balance` data class in balance feature

## Testing
- `./gradlew spotlessCheck`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aaa5b65148328b9d8efa426c1e2c7