### PR TITLE
Add KDoc to balance module

### DIFF
--- a/feature/balance/src/main/kotlin/com/thesetox/balance/BalanceModule.kt
+++ b/feature/balance/src/main/kotlin/com/thesetox/balance/BalanceModule.kt
@@ -3,6 +3,12 @@ package com.thesetox.balance
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
+/**
+ * Koin dependency module exposing balance related use cases.
+ *
+ * Registers [GetDefaultBalanceUseCase] so other components can
+ * easily retrieve the initial wallet contents when the app starts.
+ */
 val balanceModule =
     module {
         singleOf(::GetDefaultBalanceUseCase)


### PR DESCRIPTION
## Summary
- document `balanceModule`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aaa69e1d083288a30540dc28eac7f