### PR TITLE
Fix DataStoreModule docs location

### DIFF
--- a/core/datastore/src/main/kotlin/com/thesetox/datastore/DataStoreModule.kt
+++ b/core/datastore/src/main/kotlin/com/thesetox/datastore/DataStoreModule.kt
@@ -1,3 +1,13 @@
+/**
+ * Provides dependencies related to Jetpack DataStore.
+ *
+ * The [dataStoreModule] exposes a single [androidx.datastore.core.DataStore] of
+ * [androidx.datastore.preferences.core.Preferences] named `"secure_prefs"`. It
+ * also binds the [AppDataStore] interface to its implementation [LocalDataSource]
+ * so other modules can persist small pieces of data without knowing the
+ * underlying storage mechanism.
+ */
+
 package com.thesetox.datastore
 
 import android.content.Context
@@ -9,6 +19,10 @@ import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
+/**
+ * Koin module providing a DataStore instance and its [AppDataStore]
+ * implementation.
+ */
 val dataStoreModule =
     module {
         single<DataStore<Preferences>> { androidContext().dataStore }
@@ -16,4 +30,7 @@ val dataStoreModule =
         singleOf(::LocalDataSource) { bind<AppDataStore>() }
     }
 
+/**
+ * Lazily creates the application's [DataStore] named `"secure_prefs"`.
+ */
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "secure_prefs")


### PR DESCRIPTION
## Summary
- reposition header Javadoc to precede the `package` statement
- move Koin module Javadoc above `val dataStoreModule`

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aa98cf39c83289da87ca7517585f3