### PR TITLE
Add KDoc for Commission module

### DIFF
--- a/feature/comission/src/main/java/com/thesetox/comission/CommissionModule.kt
+++ b/feature/comission/src/main/java/com/thesetox/comission/CommissionModule.kt
@@ -3,6 +3,12 @@ package com.thesetox.comission
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
+/**
+ * Koin module that provides dependencies for the commission feature.
+ *
+ * Currently it exposes a singleton of [GetCommissionUseCase]. Include this
+ * module in your Koin setup to enable commission calculation.
+ */
 val commissionModule =
     module {
         singleOf(::GetCommissionUseCase)


### PR DESCRIPTION
## Summary
- document `commissionModule` with KDoc

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aaabfcd48832895231ad3cddecd42