### PR TITLE
Add KDoc for GetCommissionUseCase

### DIFF
--- a/feature/comission/src/main/java/com/thesetox/comission/GetCommissionUseCase.kt
+++ b/feature/comission/src/main/java/com/thesetox/comission/GetCommissionUseCase.kt
@@ -1,5 +1,14 @@
 package com.thesetox.comission
 
+/**
+ * Calculates the commission fee for each currency conversion.
+ *
+ * This use case keeps track of how many conversions have been made and
+ * applies rules from [CommissionConfig] to determine the fee for a given
+ * transaction. By default, the first five conversions are free and a 0.7%
+ * commission is charged afterwards. The configuration can be extended with
+ * additional rules if needed.
+ */
 class GetCommissionUseCase {
     private var conversionCount = 0
 


### PR DESCRIPTION
## Summary
- document GetCommissionUseCase with KDoc

## Testing
- `./gradlew :feature:comission:test --console=plain --no-daemon --max-workers=1` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aaad2e58c8328ba636e032cce899d