### PR TITLE
Add preview for CurrencyBottomSheet

### DIFF
--- a/feature/exchange/src/main/kotlin/com/thesetox/exchange/ui/component/BottomSheet.kt
+++ b/feature/exchange/src/main/kotlin/com/thesetox/exchange/ui/component/BottomSheet.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -41,4 +42,14 @@ fun CurrencyBottomSheet(
             }
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CurrencyBottomSheetPreview() {
+    CurrencyBottomSheet(
+        currencies = listOf("EUR", "USD", "GBP"),
+        onCurrencySelected = {},
+        onDismissRequest = {},
+    )
 }


### PR DESCRIPTION
## Summary
- implement `CurrencyBottomSheetPreview`
- ensure imports meet formatting rules

## Testing
- `./gradlew spotlessCheck`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aab4fe58483289b5a739848114de4