### PR TITLE
Add BalanceLazyRow preview

### DIFF
--- a/feature/exchange/src/main/kotlin/com/thesetox/exchange/ui/component/LazyRow.kt
+++ b/feature/exchange/src/main/kotlin/com/thesetox/exchange/ui/component/LazyRow.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.thesetox.balance.Balance
 import com.thesetox.designsystem.MediumTextStyle
@@ -17,3 +18,13 @@ fun BalanceLazyRow(listOfBalance: List<Balance>) {
         }
     }
 }
+
+@Preview(showBackground = true)
+@Composable
+private fun BalanceLazyRowPreview() =
+    BalanceLazyRow(
+        listOf(
+            Balance(code = "EUR", value = 1000.0),
+            Balance(code = "USD", value = 100.0),
+        ),
+    )


### PR DESCRIPTION
## Summary
- add a `BalanceLazyRowPreview` composable

## Testing
- `./gradlew spotlessCheck`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aab7797488328b9cfb052fa7adb00