### PR TITLE
Add ConversionRow preview

### DIFF
--- a/feature/exchange/src/main/kotlin/com/thesetox/exchange/ui/component/Row.kt
+++ b/feature/exchange/src/main/kotlin/com/thesetox/exchange/ui/component/Row.kt
@@ -88,3 +88,13 @@ private fun SellRowPreview() = SellRow()
 @Preview(showBackground = true)
 @Composable
 private fun ReceiveRowPreview() = ReceiveRow()
+
+@Preview(showBackground = true)
+@Composable
+private fun ConversionRowPreview() =
+    ConversionRow(
+        leadIcon = { LeadingIcon(color = Color.Red, drawable = R.drawable.arrow_upward) },
+        titleId = R.string.sell_label,
+        value = "100",
+        currency = "EUR",
+    )


### PR DESCRIPTION
## Summary
- show a private `ConversionRowPreview` in Exchange row component

## Testing
- `./gradlew spotlessCheck`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aabb4d44c83289081f9f3804dfa0e