### PR TITLE
Add KDoc for ConvertCurrencyUseCase

### DIFF
--- a/feature/exchange/src/main/kotlin/com/thesetox/exchange/usecase/ConvertCurrencyUseCase.kt
+++ b/feature/exchange/src/main/kotlin/com/thesetox/exchange/usecase/ConvertCurrencyUseCase.kt
@@ -3,6 +3,13 @@ package com.thesetox.exchange.usecase
 import com.thesetox.exchange.repository.ExchangeRepository
 import java.util.Locale
 
+/**
+ * Converts a given amount from one currency to another.
+ *
+ * The use case obtains the currency rates from [ExchangeRepository] and formats
+ * the result with two decimal digits using the current [Locale]. If the passed
+ * [amount] cannot be parsed, it returns `"0.00"`.
+ */
 class ConvertCurrencyUseCase(private val repository: ExchangeRepository) {
     suspend operator fun invoke(
         amount: String,


### PR DESCRIPTION
## Summary
- document ConvertCurrencyUseCase

## Testing
- `./gradlew spotlessApply --no-daemon`
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aac8975c48328bb75798904214c49