### PR TITLE
Add documentation for ExchangeCurrencyUseCase

### DIFF
--- a/feature/exchange/src/main/kotlin/com/thesetox/exchange/usecase/ExchangeCurrencyUseCase.kt
+++ b/feature/exchange/src/main/kotlin/com/thesetox/exchange/usecase/ExchangeCurrencyUseCase.kt
@@ -5,6 +5,13 @@ import com.thesetox.comission.GetCommissionUseCase
 import com.thesetox.exchange.model.ExchangeResult
 import com.thesetox.exchange.model.ExchangeResultWithUpdatedBalances
 
+/**
+ * Executes a currency exchange between two balances.
+ *
+ * The use case validates the provided amounts, applies commission via
+ * [GetCommissionUseCase], updates the balances and returns the result.
+ */
+
 class ExchangeCurrencyUseCase(private val getCommission: GetCommissionUseCase) {
     operator fun invoke(
         sellAmount: String,


### PR DESCRIPTION
## Summary
- add KDoc for `ExchangeCurrencyUseCase`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aac9a4f3c832898a8fc0042799bc5