### PR TITLE
Add GetListOfCurrencyUseCase javadoc

### DIFF
--- a/feature/exchange/src/main/kotlin/com/thesetox/exchange/usecase/GetListOfCurrencyUseCase.kt
+++ b/feature/exchange/src/main/kotlin/com/thesetox/exchange/usecase/GetListOfCurrencyUseCase.kt
@@ -4,6 +4,13 @@ import com.thesetox.exchange.repository.ExchangeRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
+/**
+ * Use case that emits a list of available currency codes.
+ *
+ * It observes [ExchangeRepository.listOfCurrencyRate] and converts each
+ * [com.thesetox.database.CurrencyRateEntity] to its corresponding currency code.
+ */
+
 class GetListOfCurrencyUseCase(private val repository: ExchangeRepository) {
     operator fun invoke(): Flow<List<String>> {
         return repository.listOfCurrencyRate.map { list -> list.map { it.currencyCode } }


### PR DESCRIPTION
## Summary
- document `GetListOfCurrencyUseCase`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aacaab2f883289c9453421f3b3226