### PR TITLE
Add KDoc to ExchangeModule

### DIFF
--- a/feature/exchange/src/main/kotlin/com/thesetox/exchange/ExchangeModule.kt
+++ b/feature/exchange/src/main/kotlin/com/thesetox/exchange/ExchangeModule.kt
@@ -1,3 +1,10 @@
+/**
+ * Koin module that wires all dependencies required by the exchange feature.
+ *
+ * This module provides the concrete implementation of [ExchangeRepository], the
+ * business use cases for currency conversion and exchange, and finally the
+ * [ExchangeViewModel] used by the UI layer.
+ */
 package com.thesetox.exchange
 
 import com.thesetox.exchange.repository.ExchangeDataRepository
@@ -11,6 +18,7 @@ import org.koin.core.module.dsl.singleOf
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 
+/** Koin module that provides repositories, use cases and the [ExchangeViewModel]. */
 val exchangeModule =
     module {
         singleOf(::ExchangeDataRepository) { bind<ExchangeRepository>() }


### PR DESCRIPTION
## Summary
- document ExchangeModule with KDoc

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aacba16c0832885f09cfd539af12a