### PR TITLE
Add javadoc for sync module

### DIFF
--- a/feature/sync/src/main/kotlin/com/thesetox/sync/SyncModule.kt
+++ b/feature/sync/src/main/kotlin/com/thesetox/sync/SyncModule.kt
@@ -4,6 +4,12 @@ import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
+/**
+ * Koin module that wires up the dependencies used by the sync feature.
+ *
+ * This module provides [SyncDataRepository] as the implementation for [SyncRepository]
+ * and exposes [SyncUseCase] so other modules can trigger synchronization.
+ */
 val syncModule =
     module {
         singleOf(::SyncDataRepository) { bind<SyncRepository>() }


### PR DESCRIPTION
## Summary
- document Koin module for the sync feature

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aad20474883289b61b288a0145baa